### PR TITLE
promise all on coll areas; abort on navigate away;

### DIFF
--- a/src/lib/Api/Collections/getAreas.js
+++ b/src/lib/Api/Collections/getAreas.js
@@ -1,87 +1,30 @@
 const MAPSERVER_AREAS_BASE_URL = `https://mapserver.tnris.org/?map=/tnris_mapfiles/download_areas.map&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=collection_query&outputformat=geojson&SRSNAME=EPSG:4326`;
 //Append areatype and collectionid like:
 //&AreaType=qquad&Collection=a6a703ba-df8b-4d1b-8d4c-ece8ae786505
+export const getMapAreasByCollectionId = async (collection_id, signal) => {
+  const qquadUrl = `${MAPSERVER_AREAS_BASE_URL}&AreaType=qquad&Collection=${collection_id}`;
+  const quadUrl = `${MAPSERVER_AREAS_BASE_URL}&AreaType=quad&Collection=${collection_id}`;
+  const countiesUrl = `${MAPSERVER_AREAS_BASE_URL}&AreaType=county&Collection=${collection_id}`;
+  const blocksUrl = `${MAPSERVER_AREAS_BASE_URL}&AreaType=block&Collection=${collection_id}`;
+  const twoFiftyKUrl = `${MAPSERVER_AREAS_BASE_URL}&AreaType=250k&Collection=${collection_id}`;
+  const stateUrl = `${MAPSERVER_AREAS_BASE_URL}&AreaType=state&Collection=${collection_id}`;
 
-export const getQQuadsByCollectionId = async (collection_id) => {
-  const resp = await fetch(
-    `${MAPSERVER_AREAS_BASE_URL}&AreaType=qquad&Collection=${collection_id}`
+  const urls = [
+    qquadUrl,
+    quadUrl,
+    countiesUrl,
+    blocksUrl,
+    twoFiftyKUrl,
+    stateUrl,
+  ];
+
+  let fetchJobs = urls.map((url) =>
+    fetch(url, { signal })
+      .then((v) => v.json())
+      .catch((e) => console.error(e?.message))
   );
 
-  if (resp.ok == false) {
-    throw new Error(
-      `Error retreiving qquad download areas from MapServer with collection id ${collection_id}`
-    );
-  }
+  let results = Promise.all([...fetchJobs]);
 
-  return resp.json();
-};
-
-export const getQuadsByCollectionId = async (collection_id) => {
-  const resp = await fetch(
-    `${MAPSERVER_AREAS_BASE_URL}&AreaType=quad&Collection=${collection_id}`
-  );
-
-  if (resp.ok == false) {
-    throw new Error(
-      `Error retreiving quad download areas from MapServer with collection id ${collection_id}`
-    );
-  }
-
-  return resp.json();
-};
-
-export const getCountiesByCollectionId = async (collection_id) => {
-  const resp = await fetch(
-    `${MAPSERVER_AREAS_BASE_URL}&AreaType=county&Collection=${collection_id}`
-  );
-
-  if (resp.ok == false) {
-    throw new Error(
-      `Error retreiving county download areas from MapServer with collection id ${collection_id}`
-    );
-  }
-
-  return resp.json();
-};
-
-export const getBlocksByCollectionId = async (collection_id) => {
-  const resp = await fetch(
-    `${MAPSERVER_AREAS_BASE_URL}&AreaType=block&Collection=${collection_id}`
-  );
-
-  if (resp.ok == false) {
-    throw new Error(
-      `Error retreiving block download areas from MapServer with collection id ${collection_id}`
-    );
-  }
-
-  return resp.json();
-};
-
-export const get250kByCollectionId = async (collection_id) => {
-  const resp = await fetch(
-    `${MAPSERVER_AREAS_BASE_URL}&AreaType=250k&Collection=${collection_id}`
-  );
-
-  if (resp.ok == false) {
-    throw new Error(
-      `Error retreiving 250km download areas from MapServer with collection id ${collection_id}`
-    );
-  }
-
-  return resp.json();
-};
-
-export const getStateByCollectionId = async (collection_id) => {
-  const resp = await fetch(
-    `${MAPSERVER_AREAS_BASE_URL}&AreaType=state&Collection=${collection_id}`
-  );
-
-  if (resp.ok == false) {
-    throw new Error(
-      `Error retreiving statewide download area from MapServer with collection id ${collection_id}`
-    );
-  }
-
-  return resp.json();
+  return results.then((v) => v).then((r) => r);
 };

--- a/src/lib/Components/Collection/Resources/AreaTypeSelect.svelte
+++ b/src/lib/Components/Collection/Resources/AreaTypeSelect.svelte
@@ -11,20 +11,20 @@
   export let areaTypeSelection;
 
   $: options = {
-    QQuad: $areasQQuad,
-    Quad: $areasQuad,
-    "250k": $areas250k,
-    Block: $areasBlock,
-    County: $areasCounty,
-    State: $areasState,
+    QQuad: areasQQuad,
+    Quad: areasQuad,
+    "250k": areas250k,
+    Block: areasBlock,
+    County: areasCounty,
+    State: areasState,
   };
 
   const onAreaTypeSelectionChange = (d) => {
-    let areas = options[d]?.data ? options[d].data : null
+    let areas = options[d]?.data ? options[d].data : null;
     if ($mapStore && areas && areas?.features.length > 0) {
       let bb = bbox(areas);
       $mapStore.fitBounds(bb, {
-        padding: 16
+        padding: 16,
       });
     }
   };
@@ -34,12 +34,12 @@
       $mapStore &&
       options &&
       areaTypeSelection &&
-      $areasQQuad &&
-      $areasQuad &&
-      $areas250k &&
-      $areasBlock &&
-      $areasCounty &&
-      $areasState
+      areasQQuad &&
+      areasQuad &&
+      areas250k &&
+      areasBlock &&
+      areasCounty &&
+      areasState
     ) {
       $mapStore;
       onAreaTypeSelectionChange(areaTypeSelection);
@@ -47,16 +47,14 @@
   }
 </script>
 
-{#if $areasQuad.data && $areasQuad.data && $areas250k.data && $areasBlock.data && $areasCounty.data && $areasState.data}
+{#if areasQuad && areasQuad && areas250k && areasBlock && areasCounty && areasState}
   <select id="area-type-select" bind:value={areaTypeSelection}>
     {#if Object.entries(options).length > 1}
-      {#each Object.entries(options).sort( (a, b) => (a[1].data?.features.length > b[1].data?.features.length ? -1 : 1) ) as arr}
-        {#if arr[1].data}
-          <option value={arr[0]} disabled={arr[1].data.length < 1}>
-            {arr[0]}
-            <div>[{arr[1].data.features.length}]</div>
-          </option>
-        {/if}
+      {#each Object.entries(options).sort( (a, b) => (a[1].numberMatched > b[1].numberMatched ? -1 : 1) ) as arr}
+        <option value={arr[0]} disabled={arr[1].numberMatched < 1}>
+          {arr[0]}
+          <div>[{arr[1].features.length}]</div>
+        </option>
       {/each}
     {/if}
   </select>

--- a/src/lib/Components/Collection/Resources/ResourcesContainer.svelte
+++ b/src/lib/Components/Collection/Resources/ResourcesContainer.svelte
@@ -1,41 +1,37 @@
 <script>
   import { useQuery } from "@sveltestack/svelte-query";
-  import * as rscs from "../../../Api/Collections/getAreas";
-  import SearchSelect from "../../General/SearchSelect.svelte";
-  import mapStore from "../../Map/mapStore";
-  import AreaTypeSelect from "./AreaTypeSelect.svelte";
-  import ResourceAreaItem from "./ResourceAreaItem.svelte";
-  import ResourceAreasMapLayer from "./ResourceAreasMapLayer.svelte";
+  import { onDestroy } from "svelte";
   import { query } from "svelte-pathfinder";
+  import * as rscs from "../../../Api/Collections/getAreas";
+  import mapStore from "../../Map/mapStore";
+  import LoadingIndicator from "../../General/LoadingIndicator.svelte";
   import InfoBox from "../../General/InfoBox.svelte";
+  import AreaTypeSelect from "./AreaTypeSelect.svelte";
+  import SearchSelect from "../../General/SearchSelect.svelte";
+  import ResourceAreasMapLayer from "./ResourceAreasMapLayer.svelte";
+  import ResourceAreaItem from "./ResourceAreaItem.svelte";
 
   export let collection_id = null;
 
   let map = mapStore;
 
-  const areas250k = useQuery(
-    ["250k-areas", collection_id],
-    async () => await rscs.get250kByCollectionId(collection_id)
-  );
-  const areasBlock = useQuery(
-    ["block-areas", collection_id],
-    async () => await rscs.getBlocksByCollectionId(collection_id)
-  );
-  const areasCounty = useQuery(
-    ["county-areas", collection_id],
-    async () => await rscs.getCountiesByCollectionId(collection_id)
-  );
-  const areasQuad = useQuery(
-    ["quad-areas", collection_id],
-    async () => await rscs.getQuadsByCollectionId(collection_id)
-  );
-  const areasQQuad = useQuery(
-    ["qquad-areas", collection_id],
-    async () => await rscs.getQQuadsByCollectionId(collection_id)
-  );
-  const areasState = useQuery(
-    ["state-areas", collection_id],
-    async () => await rscs.getStateByCollectionId(collection_id)
+  // TODO! //////////////////////////////////////////////////////////////////////////
+  //////////// use query seems to be encountering a race condition
+  //////////// this causes the wrong collections to load for a collection
+  //////////// if the user has not allowed the areas to load fully before navigating
+  //////////// away from the collection
+  //////////// look into https://sveltequery.vercel.app/guides/query-cancellation
+  ///////////////////////////////////////////////////////////////////////////////////
+
+  const controller = new AbortController();
+  // Get the abortController's signal
+  const signal = controller.signal;
+
+  let areas;
+
+  const queryAreas = useQuery(
+    ["123collection-areas-12121", collection_id],
+    () => rscs.getMapAreasByCollectionId(collection_id, signal)
   );
 
   let areaTypeSelection;
@@ -67,169 +63,179 @@
       $query.params.activeTab = "Downloads";
     }
   };
+
+  onDestroy(() => {
+    controller.abort();
+  });
 </script>
 
 <section id="collection-resources-container">
-  <InfoBox infoClass="info">
-    Select one or more areas from the searchable list below or from the map to
-    view available resources for each respective area for this collection.
-  </InfoBox>
-  <br />
-  <div id="collection-resources-area-select">
-    <AreaTypeSelect
-      bind:areaTypeSelection
-      {areas250k}
-      {areasBlock}
-      {areasCounty}
-      {areasQQuad}
-      {areasQuad}
-      {areasState}
-    />
-    {#if areaTypeSelection == "State"}
-      <SearchSelect
-        options={$areasState.data.features
-          .map((v) => {
+  {#if $queryAreas.status === "loading"}
+    <LoadingIndicator />
+  {:else if $queryAreas.status === "error"}
+    <h3>ERROR: {$queryAreas.error}</h3>
+  {:else if $queryAreas.status === "success"}
+    <InfoBox infoClass="info">
+      Select one or more areas from the searchable list below or from the map to
+      view available resources for each respective area for this collection.
+    </InfoBox>
+    <br />
+    <div id="collection-resources-area-select">
+      <AreaTypeSelect
+        bind:areaTypeSelection
+        areasQQuad={$queryAreas.data[0]}
+        areasQuad={$queryAreas.data[1]}
+        areasCounty={$queryAreas.data[2]}
+        areasBlock={$queryAreas.data[3]}
+        areas250k={$queryAreas.data[4]}
+        areasState={$queryAreas.data[5]}
+      />
+      {#if areaTypeSelection == "State"}
+        <SearchSelect
+          options={$queryAreas.data[5].features
+            .map((v) => {
+              return {
+                label: v.properties.area_type_name,
+                value: v.properties.area_type_id,
+              };
+            })
+            .sort((a, b) => {
+              if (a.label > b.label) {
+                return -1;
+              }
+              if (a.label > b.label) {
+                return 1;
+              }
+              if (a.label == b.label) {
+                return 0;
+              }
+            })}
+          bind:selections={areaSelections}
+        />
+        <ResourceAreasMapLayer
+          map={$map}
+          data={$queryAreas.data[5]}
+          layerId={"tnris-resources-areas"}
+          {onAreaClick}
+          selections={areaSelections}
+          bind:hoverAreaTypeId
+        />
+      {/if}
+      {#if areaTypeSelection == "County"}
+        <SearchSelect
+          options={$queryAreas.data[2].features.map((v) => {
             return {
               label: v.properties.area_type_name,
               value: v.properties.area_type_id,
             };
-          })
-          .sort((a, b) => {
-            if (a.label > b.label) {
-              return -1;
-            }
-            if (a.label > b.label) {
-              return 1;
-            }
-            if (a.label == b.label) {
-              return 0;
-            }
           })}
-        bind:selections={areaSelections}
-      />
-      <ResourceAreasMapLayer
-        map={$map}
-        data={$areasState.data}
-        layerId={"tnris-resources-areas"}
-        {onAreaClick}
-        selections={areaSelections}
-        bind:hoverAreaTypeId
-      />
-    {/if}
-    {#if areaTypeSelection == "County"}
-      <SearchSelect
-        options={$areasCounty.data.features.map((v) => {
-          return {
-            label: v.properties.area_type_name,
-            value: v.properties.area_type_id,
-          };
-        })}
-        bind:selections={areaSelections}
-      />
-      <ResourceAreasMapLayer
-        map={$map}
-        data={$areasCounty.data}
-        layerId={"tnris-resources-areas"}
-        {onAreaClick}
-        selections={areaSelections}
-        bind:hoverAreaTypeId
-      />
-    {/if}
-    {#if areaTypeSelection == "Block"}
-      <SearchSelect
-        options={$areasBlock.data.features.map((v) => {
-          return {
-            label: v.properties.area_type_name,
-            value: v.properties.area_type_id,
-          };
-        })}
-        bind:selections={areaSelections}
-      />
-      <ResourceAreasMapLayer
-        map={$map}
-        data={$areasBlock.data}
-        layerId={"tnris-resources-areas"}
-        {onAreaClick}
-        selections={areaSelections}
-        bind:hoverAreaTypeId
-      />
-    {/if}
-    {#if areaTypeSelection == "250k"}
-      <SearchSelect
-        options={$areas250k.data.features.map((v) => {
-          return {
-            label: v.properties.area_type_name,
-            value: v.properties.area_type_id,
-          };
-        })}
-        bind:selections={areaSelections}
-      />
-      <ResourceAreasMapLayer
-        map={$map}
-        data={$areas250k.data}
-        layerId={"tnris-resources-areas"}
-        {onAreaClick}
-        selections={areaSelections}
-        bind:hoverAreaTypeId
-      />
-    {/if}
-    {#if areaTypeSelection == "Quad"}
-      <SearchSelect
-        options={$areasQuad.data.features.map((v) => {
-          return {
-            label: v.properties.area_type_name,
-            value: v.properties.area_type_id,
-          };
-        })}
-        bind:selections={areaSelections}
-      />
-      <ResourceAreasMapLayer
-        map={$map}
-        data={$areasQuad.data}
-        layerId={"tnris-resources-areas"}
-        {onAreaClick}
-        selections={areaSelections}
-        bind:hoverAreaTypeId
-      />
-    {/if}
-    {#if areaTypeSelection == "QQuad"}
-      <SearchSelect
-        options={$areasQQuad.data.features.map((v) => {
-          return {
-            label: v.properties.area_type_name,
-            value: v.properties.area_type_id,
-          };
-        })}
-        bind:selections={areaSelections}
-      />
-      <ResourceAreasMapLayer
-        map={$map}
-        data={$areasQQuad.data}
-        layerId={"tnris-resources-areas"}
-        {onAreaClick}
-        selections={areaSelections}
-        bind:hoverAreaTypeId
-      />
-    {/if}
-  </div>
+          bind:selections={areaSelections}
+        />
+        <ResourceAreasMapLayer
+          map={$map}
+          data={$queryAreas.data[2]}
+          layerId={"tnris-resources-areas"}
+          {onAreaClick}
+          selections={areaSelections}
+          bind:hoverAreaTypeId
+        />
+      {/if}
+      {#if areaTypeSelection == "Block"}
+        <SearchSelect
+          options={$queryAreas.data[3].features.map((v) => {
+            return {
+              label: v.properties.area_type_name,
+              value: v.properties.area_type_id,
+            };
+          })}
+          bind:selections={areaSelections}
+        />
+        <ResourceAreasMapLayer
+          map={$map}
+          data={$queryAreas.data[3]}
+          layerId={"tnris-resources-areas"}
+          {onAreaClick}
+          selections={areaSelections}
+          bind:hoverAreaTypeId
+        />
+      {/if}
+      {#if areaTypeSelection == "250k"}
+        <SearchSelect
+          options={$queryAreas.data[4].features?.map((v) => {
+            return {
+              label: v.properties.area_type_name,
+              value: v.properties.area_type_id,
+            };
+          })}
+          bind:selections={areaSelections}
+        />
+        <ResourceAreasMapLayer
+          map={$map}
+          data={$queryAreas.data[4]}
+          layerId={"tnris-resources-areas"}
+          {onAreaClick}
+          selections={areaSelections}
+          bind:hoverAreaTypeId
+        />
+      {/if}
+      {#if areaTypeSelection == "Quad"}
+        <SearchSelect
+          options={$queryAreas.data[1].features.map((v) => {
+            return {
+              label: v.properties.area_type_name,
+              value: v.properties.area_type_id,
+            };
+          })}
+          bind:selections={areaSelections}
+        />
+        <ResourceAreasMapLayer
+          map={$map}
+          data={$queryAreas.data[1]}
+          layerId={"tnris-resources-areas"}
+          {onAreaClick}
+          selections={areaSelections}
+          bind:hoverAreaTypeId
+        />
+      {/if}
+      {#if areaTypeSelection == "QQuad"}
+        <SearchSelect
+          options={$queryAreas.data[0].features.map((v) => {
+            return {
+              label: v.properties.area_type_name,
+              value: v.properties.area_type_id,
+            };
+          })}
+          bind:selections={areaSelections}
+        />
+        <ResourceAreasMapLayer
+          map={$map}
+          data={$queryAreas.data[0]}
+          layerId={"tnris-resources-areas"}
+          {onAreaClick}
+          selections={areaSelections}
+          bind:hoverAreaTypeId
+        />
+      {/if}
+    </div>
 
-  <section id="area-selections-resource-list-container">
-    {#each areaSelections as area}
-      <ResourceAreaItem
-        resourceAreaId={area.value}
-        resourceAreaName={area.label}
-        collectionId={collection_id}
-        removeResourceSelectionFn={removeSelection}
-        bind:hoverAreaTypeId
-      />
-    {/each}
-  </section>
+    <section id="area-selections-resource-list-container">
+      {#each areaSelections as area}
+        <ResourceAreaItem
+          resourceAreaId={area.value}
+          resourceAreaName={area.label}
+          collectionId={collection_id}
+          removeResourceSelectionFn={removeSelection}
+          bind:hoverAreaTypeId
+        />
+      {/each}
+    </section>
+  {/if}
 </section>
 
 <style lang="scss">
   #collection-resources-container {
     display: grid;
-    gap: .25rem;
+    gap: 0.25rem;
     grid-template-rows: auto 1fr;
     max-height: 100%;
     overflow-y: auto;

--- a/src/lib/Components/Collection/Tabs.svelte
+++ b/src/lib/Components/Collection/Tabs.svelte
@@ -1,6 +1,5 @@
 <script>
   import { query } from "svelte-pathfinder";
-  import InfoBox from "../General/InfoBox.svelte";
   import CollectionContactForm from "./Contact/CollectionContactForm.svelte";
   import CustomOrderForm from "./CustomOrder/CustomOrderForm.svelte";
   import Downloads from "./Downloads.svelte";


### PR DESCRIPTION
### PROBLEM
When navigating to a collection, then quickly away and quickly into another one, the wrong Download Area Tiles were loading in the map. That meant when users clicked on certain areas, like a qquad, it would show as "No resources for this area in this collection".

This happens when navigating to a collection with a lot of map tiles, say, for instance, a NAIP collection. If navigating away, the network request to fetch the area tiles for NAIP were not finished fetching. So, if you navigate quickly to a collection with very few tiles - for instance, WaterShed Boundaries, the network request for Watershed Boundaries Download Areas would complete for the request for the NAIP collection. So the tiles would load for WaterShed, then were soon replaced by NAIP tiles even though you were still in the WaterShed collection.

### SOLUTION
The solution was frustratingly simple, but difficult to catch. If you never navigate away from a large collection to small quickly enough, you would never see this error. So if you pass the network request a signal, you can abort the network request in the browser when navigating away from a collection. This means the NAIP Areas will be cancelled before you get to the WaterShed collection and won't be overwritten.